### PR TITLE
[codex] Configure post sync workflow for Postgres

### DIFF
--- a/.github/workflows/sync-posts.yml
+++ b/.github/workflows/sync-posts.yml
@@ -1,4 +1,4 @@
-name: Sync posts to Supabase
+name: Sync posts to database
 
 on:
   push:
@@ -33,5 +33,5 @@ jobs:
       - name: Sync posts
         run: pnpm sync:posts
         env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          BLOG_DATABASE_PROVIDER: postgres
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}


### PR DESCRIPTION
## What changed

- Rename the post sync workflow to target the database generically.
- Run `pnpm sync:posts` with `BLOG_DATABASE_PROVIDER=postgres`.
- Pass `DATABASE_URL` from GitHub Actions secrets instead of the old Supabase REST secrets.

## Why

The production deployment now uses the Postgres direct path and runs migrations against `DATABASE_URL`. The post sync workflow should use the same database path instead of failing on missing `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` secrets.

## Required secret

Set this repository secret before relying on the sync workflow:

- `DATABASE_URL`

## Validation

This is a workflow-only change. The previous failure was caused by empty Supabase secrets in the GitHub Actions environment.