### PR TITLE
[codex] Improve blog detail UX

### DIFF
--- a/app/_localized/post.tsx
+++ b/app/_localized/post.tsx
@@ -1,10 +1,12 @@
 import { PostArticle } from "@/components/PostArticle";
-import { localeHomePath, localizedAlternates, type Locale } from "@/lib/i18n";
+import { localeHomePath, type Locale } from "@/lib/i18n";
+import { createPostMetadata, localizedPostAlternates } from "@/lib/post-metadata";
 import { getPublishedPostByAnyLocaleSlugOrCanonicalSlug, getPublishedPostBySlugOrCanonicalSlug } from "@/lib/posts";
 import { canonicalPostSlug } from "@/lib/slug";
 import { postPath } from "@/lib/urls";
 import type { Metadata } from "next";
 import { notFound, permanentRedirect } from "next/navigation";
+import { cache } from "react";
 
 type PostParams = {
   slug: string;
@@ -19,15 +21,7 @@ export async function postMetadata(locale: Locale, params: PostParams): Promise<
     };
   }
 
-  return {
-    title: post.title,
-    description: post.excerpt ?? undefined,
-    authors: [{ name: post.author }],
-    alternates: {
-      canonical: postPath(post),
-      languages: localizedAlternates(`/posts/${canonicalPostSlug(post.translation_key)}`)
-    }
-  };
+  return createPostMetadata(post, localizedPostAlternates(post));
 }
 
 export async function LocalizedPostPage({ locale, params }: { locale: Locale; params: PostParams }) {
@@ -52,12 +46,12 @@ export async function LocalizedPostPage({ locale, params }: { locale: Locale; pa
   return <PostArticle post={post} locale={locale} />;
 }
 
-async function loadPost(locale: Locale, slugParam: string) {
+const loadPost = cache(async (locale: Locale, slugParam: string) => {
   const slug = canonicalPostSlug(decodeURIComponent(slugParam));
   return getPublishedPostBySlugOrCanonicalSlug(slug, locale);
-}
+});
 
-async function loadAnyLocalePost(slugParam: string) {
+const loadAnyLocalePost = cache(async (slugParam: string) => {
   const slug = canonicalPostSlug(decodeURIComponent(slugParam));
   return getPublishedPostByAnyLocaleSlugOrCanonicalSlug(slug);
-}
+});

--- a/app/en/posts/[slug]/loading.tsx
+++ b/app/en/posts/[slug]/loading.tsx
@@ -1,0 +1,5 @@
+import { PostArticleLoading } from "@/components/PostArticleLoading";
+
+export default function Loading() {
+  return <PostArticleLoading locale="en" />;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -14,6 +14,8 @@
   --excerpt: #4c4c4c;
   --quote: #4b4b4b;
   --table-header: #f9f9f9;
+  --hover-fill: rgba(0, 0, 0, 0.035);
+  --loading-surface: rgba(0, 0, 0, 0.055);
   --max-width: 800px;
   color-scheme: light;
 }
@@ -34,6 +36,8 @@
   --excerpt: #c7c7c7;
   --quote: #c9c9c9;
   --table-header: #232323;
+  --hover-fill: rgba(255, 255, 255, 0.055);
+  --loading-surface: rgba(255, 255, 255, 0.08);
   color-scheme: dark;
 }
 
@@ -105,15 +109,6 @@ a:hover {
   gap: 18px;
 }
 
-.site-actions {
-  display: grid;
-  grid-template-columns: 32px;
-  padding: 4px;
-  background: var(--panel);
-  border: 1px solid color-mix(in srgb, var(--border), transparent 45%);
-  border-radius: 999px;
-}
-
 .site-action-button {
   display: grid;
   width: 32px;
@@ -122,18 +117,22 @@ a:hover {
   padding: 0;
   color: var(--foreground);
   background: transparent;
-  border: 0;
+  border: 1px solid transparent;
   border-radius: 999px;
   cursor: pointer;
   font: inherit;
   font-size: 13px;
   line-height: 1;
   text-decoration: none;
+  transition:
+    background 160ms ease,
+    border-color 160ms ease;
 }
 
 .site-action-button:hover,
 .site-action-button:focus-visible {
-  background: var(--panel-active);
+  background: var(--panel);
+  border-color: color-mix(in srgb, var(--border), transparent 35%);
   outline: none;
   text-decoration: none;
 }
@@ -156,11 +155,24 @@ a:hover {
 }
 
 .post-list-item {
+  position: relative;
   display: block;
+  overflow: hidden;
   padding: 40px 0 44px 16px;
   border-left: 2px solid transparent;
   border-bottom: 1px solid var(--border);
   transition: border-color 160ms ease;
+}
+
+.post-list-item::before {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  content: "";
+  background: var(--hover-fill);
+  transform: scaleX(0);
+  transform-origin: left center;
+  transition: transform 220ms ease;
 }
 
 .post-list-item:hover,
@@ -170,17 +182,16 @@ a:hover {
   text-decoration: none;
 }
 
-.post-list-item article {
-  display: grid;
-  gap: 13px;
-  transform: translateX(0);
-  transition: transform 160ms ease;
-  will-change: transform;
+.post-list-item:hover::before,
+.post-list-item:focus-visible::before {
+  transform: scaleX(1);
 }
 
-.post-list-item:hover article,
-.post-list-item:focus-visible article {
-  transform: translateX(4px);
+.post-list-item article {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 13px;
 }
 
 .post-list-title {
@@ -210,6 +221,26 @@ a:hover {
 
 .post-page {
   padding: 56px 0;
+}
+
+.post-back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 28px;
+  padding: 8px 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1;
+  text-decoration: none;
+  transition: color 160ms ease;
+}
+
+.post-back-link:hover,
+.post-back-link:focus-visible {
+  color: var(--foreground);
+  outline: none;
+  text-decoration: none;
 }
 
 .post-header {
@@ -340,6 +371,89 @@ a:hover {
 .markdown-body ul,
 .markdown-body ol {
   padding-left: 1.35em;
+}
+
+.post-body-loading {
+  display: grid;
+  gap: 16px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.post-loading-meta,
+.post-loading-title,
+.post-loading-line,
+.post-loading-block,
+.post-divider-loading {
+  overflow: hidden;
+  background: linear-gradient(90deg, var(--loading-surface), var(--hover-fill), var(--loading-surface));
+  background-size: 200% 100%;
+  border-radius: 6px;
+  animation: loading-shimmer 1.3s ease-in-out infinite;
+}
+
+.post-loading-meta {
+  width: 220px;
+  height: 18px;
+  margin: 0 auto 18px;
+}
+
+.post-loading-title {
+  width: min(560px, 82%);
+  height: 54px;
+  margin: 16px auto;
+}
+
+.post-divider-loading {
+  background-color: var(--loading-surface);
+}
+
+.post-loading-line {
+  width: 100%;
+  height: 18px;
+}
+
+.post-loading-line-short {
+  width: 58%;
+}
+
+.post-loading-line-mid {
+  width: 74%;
+}
+
+.post-loading-block {
+  width: 100%;
+  height: 180px;
+}
+
+.post-back-link-loading {
+  pointer-events: none;
+}
+
+@keyframes loading-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .post-list-item::before,
+  .post-loading-meta,
+  .post-loading-title,
+  .post-loading-line,
+  .post-loading-block,
+  .post-divider-loading {
+    animation: none;
+    transition: none;
+  }
 }
 
 .empty-state,

--- a/app/posts/[slug]/loading.tsx
+++ b/app/posts/[slug]/loading.tsx
@@ -1,0 +1,5 @@
+import { PostArticleLoading } from "@/components/PostArticleLoading";
+
+export default function Loading() {
+  return <PostArticleLoading locale="zh" />;
+}

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -1,9 +1,11 @@
 import { PostArticle } from "@/components/PostArticle";
+import { createPostMetadata } from "@/lib/post-metadata";
 import { getPublishedPostByAnyLocaleSlugOrCanonicalSlug } from "@/lib/posts";
 import { canonicalPostSlug } from "@/lib/slug";
 import { postPath } from "@/lib/urls";
 import type { Metadata } from "next";
 import { notFound, permanentRedirect } from "next/navigation";
+import { cache } from "react";
 
 export const dynamic = "force-dynamic";
 
@@ -16,7 +18,8 @@ type Props = {
 };
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const post = await loadPost(await params);
+  const { slug } = await params;
+  const post = await loadPost(slug);
 
   if (!post) {
     return {
@@ -24,18 +27,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     };
   }
 
-  return {
-    title: post.title,
-    description: post.excerpt ?? undefined,
-    authors: [{ name: post.author }],
-    alternates: {
-      canonical: postPath(post)
-    }
-  };
+  return createPostMetadata(post);
 }
 
 export default async function PostPage({ params }: Props) {
-  const post = await loadPost(await params);
+  const { slug } = await params;
+  const post = await loadPost(slug);
 
   if (!post) {
     notFound();
@@ -43,14 +40,14 @@ export default async function PostPage({ params }: Props) {
 
   const path = postPath(post);
 
-  if (path !== `/posts/${encodeURIComponent(decodeURIComponent((await params).slug))}`) {
+  if (path !== `/posts/${encodeURIComponent(decodeURIComponent(slug))}`) {
     permanentRedirect(path);
   }
 
   return <PostArticle post={post} locale={post.locale} />;
 }
 
-async function loadPost(params: Params) {
-  const slug = canonicalPostSlug(decodeURIComponent(params.slug));
+const loadPost = cache(async (slugParam: string) => {
+  const slug = canonicalPostSlug(decodeURIComponent(slugParam));
   return getPublishedPostByAnyLocaleSlugOrCanonicalSlug(slug);
-}
+});

--- a/app/zh/posts/[slug]/loading.tsx
+++ b/app/zh/posts/[slug]/loading.tsx
@@ -1,0 +1,5 @@
+import { PostArticleLoading } from "@/components/PostArticleLoading";
+
+export default function Loading() {
+  return <PostArticleLoading locale="zh" />;
+}

--- a/components/PostArticle.tsx
+++ b/components/PostArticle.tsx
@@ -1,13 +1,19 @@
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
-import { getDictionary, type Locale } from "@/lib/i18n";
+import { getDictionary, localeHomePath, type Locale } from "@/lib/i18n";
 import type { PublishedPost } from "@/lib/posts";
 import { formatDisplayDate } from "@/lib/urls";
+import Link from "next/link";
+import { Suspense } from "react";
 
 export function PostArticle({ post, locale }: { post: PublishedPost; locale: Locale }) {
   const dict = getDictionary(locale);
 
   return (
     <article className="post-page">
+      <Link className="post-back-link" href={localeHomePath(locale)}>
+        <span aria-hidden="true">←</span>
+        <span>{dict.posts.backToPosts}</span>
+      </Link>
       <header className="post-header">
         <div className="post-meta">
           <span>
@@ -21,7 +27,22 @@ export function PostArticle({ post, locale }: { post: PublishedPost; locale: Loc
         <h1 className="post-title">{post.title}</h1>
         <div className="post-divider" />
       </header>
-      <MarkdownRenderer markdown={post.content_markdown} />
+      <Suspense fallback={<PostBodyFallback label={dict.posts.loading} />}>
+        <MarkdownRenderer markdown={post.content_markdown} />
+      </Suspense>
     </article>
+  );
+}
+
+function PostBodyFallback({ label }: { label: string }) {
+  return (
+    <div className="post-body-loading" role="status" aria-live="polite" aria-label={label}>
+      <span>{label}</span>
+      <div className="post-loading-line" />
+      <div className="post-loading-line post-loading-line-short" />
+      <div className="post-loading-block" />
+      <div className="post-loading-line" />
+      <div className="post-loading-line post-loading-line-mid" />
+    </div>
   );
 }

--- a/components/PostArticleLoading.tsx
+++ b/components/PostArticleLoading.tsx
@@ -1,0 +1,27 @@
+import { getDictionary, type Locale } from "@/lib/i18n";
+
+export function PostArticleLoading({ locale }: { locale: Locale }) {
+  const dict = getDictionary(locale);
+
+  return (
+    <div className="post-page post-page-loading" role="status" aria-live="polite" aria-label={dict.posts.loading}>
+      <div className="post-back-link post-back-link-loading">
+        <span aria-hidden="true">←</span>
+        <span>{dict.posts.backToPosts}</span>
+      </div>
+      <header className="post-header">
+        <div className="post-loading-meta" />
+        <div className="post-loading-title" />
+        <div className="post-divider post-divider-loading" />
+      </header>
+      <div className="post-body-loading">
+        <span>{dict.posts.loading}</span>
+        <div className="post-loading-line" />
+        <div className="post-loading-line post-loading-line-short" />
+        <div className="post-loading-block" />
+        <div className="post-loading-line" />
+        <div className="post-loading-line post-loading-line-mid" />
+      </div>
+    </div>
+  );
+}

--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -49,17 +49,15 @@ export function SiteHeader() {
             {dict.nav.about}
           </Link>
         </nav>
-        <div className="site-actions" aria-label="Display settings">
-          <button
-            className="site-action-button"
-            type="button"
-            onClick={toggleTheme}
-            aria-label={dict.actions.switchTheme}
-            title={theme === "dark" ? dict.actions.lightTheme : dict.actions.darkTheme}
-          >
-            <span aria-hidden="true">{theme === "dark" ? "☀" : "☾"}</span>
-          </button>
-        </div>
+        <button
+          className="site-action-button"
+          type="button"
+          onClick={toggleTheme}
+          aria-label={dict.actions.switchTheme}
+          title={theme === "dark" ? dict.actions.lightTheme : dict.actions.darkTheme}
+        >
+          <span aria-hidden="true">{theme === "dark" ? "☀" : "☾"}</span>
+        </button>
       </div>
     </header>
   );

--- a/content/posts/2025-04-15-UnitTestMcp.md
+++ b/content/posts/2025-04-15-UnitTestMcp.md
@@ -3,7 +3,7 @@ title: 组件库单元测试完全自动化生成
 slug: UnitTestMcp
 author: Qizheng Han
 publishedAt: 2025-04-15
-status: published
+status: draft
 excerpt: 组件库单元测试完全自动化生成 TLDR; > 感兴趣的话，请看这里 unit_test_generator_mcp_server 通过构建
   MCP server 的方式，将组件库源代码进行暴露。原先的手动操作命令行的部分全部移除，变为 Cursor Agent 调用 mcp tools 的方式。
   AI 生成单元测进化史

--- a/content/posts/2025-04-16-MediaKitMcp.md
+++ b/content/posts/2025-04-16-MediaKitMcp.md
@@ -3,7 +3,7 @@ title: 资源池 Media Kit 关键信息提取
 slug: MediaKitMcp
 author: Qizheng Han
 publishedAt: 2025-04-16
-status: published
+status: draft
 excerpt: TLDR; > 感兴趣的话，项目代码在这里：media_kit_mcp_server 什么是 Media Kit？ Media
   Kit（媒体资料包）是一种专业化的工具，用于向广告主、合作伙伴、媒体机构或其他利益相关方展示品牌、平台或个人的核心信息、受众数据和商业合作价值。
   可以简单的理解为一个自我推销介绍。 为什么要完

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -21,6 +21,8 @@ type Dictionary = {
     draft: string;
     writtenBy: string;
     publishedOn: string;
+    backToPosts: string;
+    loading: string;
   };
   about: {
     paragraphs: string[];
@@ -51,7 +53,9 @@ export const dictionaries: Record<Locale, Dictionary> = {
       empty: "还没有文章。",
       draft: "草稿",
       writtenBy: "作者",
-      publishedOn: "发布于"
+      publishedOn: "发布于",
+      backToPosts: "返回文章",
+      loading: "文章加载中"
     },
     about: {
       paragraphs: ["你好，我是韩启正。", "Welcome to the real world,", "it sucks, you're gonna love it!"]
@@ -80,7 +84,9 @@ export const dictionaries: Record<Locale, Dictionary> = {
       empty: "No posts yet.",
       draft: "Draft",
       writtenBy: "Written by",
-      publishedOn: "on"
+      publishedOn: "on",
+      backToPosts: "Back to posts",
+      loading: "Loading post"
     },
     about: {
       paragraphs: ["Hi, I am Qizheng Han.", "Welcome to the real world,", "it sucks, you're gonna love it!"]

--- a/lib/post-metadata.ts
+++ b/lib/post-metadata.ts
@@ -1,0 +1,84 @@
+import { localizedAlternates } from "@/lib/i18n";
+import type { PublishedPost } from "@/lib/posts";
+import { canonicalPostSlug } from "@/lib/slug";
+import { postPath, siteUrl } from "@/lib/urls";
+import type { Metadata } from "next";
+
+type LanguageAlternates = NonNullable<Metadata["alternates"]>["languages"];
+
+export function createPostMetadata(post: PublishedPost, languages?: LanguageAlternates): Metadata {
+  const canonicalPath = postPath(post);
+  const canonicalUrl = absoluteSiteUrl(canonicalPath);
+  const description = summarizeMetadataText(post.excerpt ?? post.content_markdown);
+  const imageUrl = findFirstMarkdownImageUrl(post.content_markdown);
+  const images = imageUrl ? [{ url: imageUrl, alt: post.title }] : undefined;
+
+  return {
+    title: post.title,
+    description,
+    authors: [{ name: post.author }],
+    alternates: {
+      canonical: canonicalPath,
+      languages
+    },
+    openGraph: {
+      type: "article",
+      title: post.title,
+      description,
+      url: canonicalUrl,
+      siteName: "「Handler」",
+      locale: post.locale === "zh" ? "zh_CN" : "en_US",
+      alternateLocale: [post.locale === "zh" ? "en_US" : "zh_CN"],
+      authors: [post.author],
+      publishedTime: post.published_at ?? undefined,
+      images
+    },
+    twitter: {
+      card: imageUrl ? "summary_large_image" : "summary",
+      title: post.title,
+      description,
+      images: imageUrl ? [imageUrl] : undefined
+    }
+  };
+}
+
+export function localizedPostAlternates(post: Pick<PublishedPost, "translation_key">) {
+  return localizedAlternates(`/posts/${canonicalPostSlug(post.translation_key)}`);
+}
+
+function summarizeMetadataText(value: string) {
+  const normalized = value
+    .replace(/!\[[^\]]*]\([^)]+\)/g, " ")
+    .replace(/\[([^\]]+)]\([^)]+\)/g, "$1")
+    .replace(/[#>*_`|~]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  const characters = Array.from(normalized);
+
+  return characters.length > 180 ? `${characters.slice(0, 180).join("").trimEnd()}...` : normalized;
+}
+
+function findFirstMarkdownImageUrl(markdown: string) {
+  const match = markdown.match(/!\[[^\]]*]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)/);
+
+  if (!match) {
+    return undefined;
+  }
+
+  return absoluteSiteUrl(normalizeImagePath(match[1]));
+}
+
+function normalizeImagePath(src: string) {
+  const withoutQuery = src.split(/[?#]/)[0];
+  const assetIndex = withoutQuery.indexOf("assets/img/");
+
+  if (assetIndex >= 0) {
+    return `/${withoutQuery.slice(assetIndex)}`;
+  }
+
+  return withoutQuery;
+}
+
+function absoluteSiteUrl(pathOrUrl: string) {
+  return new URL(pathOrUrl, siteUrl()).toString();
+}

--- a/lib/postgres-posts.ts
+++ b/lib/postgres-posts.ts
@@ -1,11 +1,14 @@
 import { getPostgresPool, type PostRecord, type PostStatus } from "@/lib/db";
 import { DEFAULT_LOCALE, type Locale } from "@/lib/i18n";
+import { canonicalPostSlug } from "@/lib/slug";
 
 type PostRow = PostRecord & {
   created_at: Date | string;
   published_at: Date | string | null;
   updated_at: Date | string;
 };
+
+type PostSlugRow = Pick<PostRecord, "id" | "slug" | "translation_key">;
 
 export async function listPostgresPublishedPosts() {
   const { rows } = await getPostgresPool().query<PostRow>(
@@ -37,6 +40,30 @@ export async function getPostgresPostBySlug(slug: string, locale: Locale = DEFAU
     "select * from public.posts where locale = $1 and slug = $2 limit 1",
     [locale, slug]
   );
+
+  return rows[0] ? normalizePostRow(rows[0]) : null;
+}
+
+export async function getPostgresPostBySlugOrCanonicalSlug(slug: string, locale: Locale = DEFAULT_LOCALE) {
+  const direct = await getPostgresPostBySlug(slug, locale);
+
+  if (direct) {
+    return direct;
+  }
+
+  const { rows: slugRows } = await getPostgresPool().query<PostSlugRow>(
+    "select id, slug, translation_key from public.posts where locale = $1",
+    [locale]
+  );
+  const match = slugRows.find((post) => matchesPostSlug(post, slug));
+
+  if (!match) {
+    return null;
+  }
+
+  const { rows } = await getPostgresPool().query<PostRow>("select * from public.posts where id = $1 limit 1", [
+    match.id
+  ]);
 
   return rows[0] ? normalizePostRow(rows[0]) : null;
 }
@@ -121,4 +148,8 @@ function normalizePostRow(row: PostRow): PostRecord {
 
 function normalizeDate(value: Date | string) {
   return value instanceof Date ? value.toISOString() : value;
+}
+
+function matchesPostSlug(post: Pick<PostRecord, "slug" | "translation_key">, slug: string) {
+  return post.slug === slug || canonicalPostSlug(post.slug) === slug || canonicalPostSlug(post.translation_key) === slug;
 }

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -10,8 +10,8 @@ import {
 import {
   createPostgresApiPost,
   getPostgresPostBySlug,
+  getPostgresPostBySlugOrCanonicalSlug,
   getPostgresPublishedPostByLegacyPath,
-  listPostgresPosts,
   listPostgresPublishedPosts,
   listPostgresPublishedPostsByLocale
 } from "@/lib/postgres-posts";
@@ -97,15 +97,13 @@ export async function getPostBySlugOrCanonicalSlug(slug: string, locale: Locale 
   }
 
   if (provider === "postgres") {
-    const direct = await getPostgresPostBySlug(slug, locale);
-
-    if (direct) {
-      return direct;
-    }
-
-    return (await listPostgresPosts(locale)).find((post) => matchesPostSlug(post, slug)) ?? null;
+    return getPostgresPostBySlugOrCanonicalSlug(slug, locale);
   }
 
+  return getSupabasePostBySlugOrCanonicalSlug(slug, locale);
+}
+
+async function getSupabasePostBySlugOrCanonicalSlug(slug: string, locale: Locale) {
   const direct = await getPostBySlug(slug, locale);
 
   if (direct) {
@@ -113,13 +111,30 @@ export async function getPostBySlugOrCanonicalSlug(slug: string, locale: Locale 
   }
 
   const supabase = getSupabaseAdmin();
-  const { data, error } = await supabase.from("posts").select("*").eq("locale", locale);
+  const { data: slugRows, error: slugError } = await supabase
+    .from("posts")
+    .select("id, slug, translation_key")
+    .eq("locale", locale);
 
-  if (error) {
-    throw new Error(`Failed to load posts: ${error.message}`);
+  if (slugError) {
+    throw new Error(`Failed to load post slugs: ${slugError.message}`);
   }
 
-  return ((data ?? []) as PostRecord[]).find((post) => matchesPostSlug(post, slug)) ?? null;
+  const match = ((slugRows ?? []) as Pick<PostRecord, "id" | "slug" | "translation_key">[]).find((post) =>
+    matchesPostSlug(post, slug)
+  );
+
+  if (!match) {
+    return null;
+  }
+
+  const { data, error } = await supabase.from("posts").select("*").eq("id", match.id).maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to load post: ${error.message}`);
+  }
+
+  return data as PostRecord | null;
 }
 
 export async function getPublishedPostBySlugOrCanonicalSlug(slug: string, locale: Locale = DEFAULT_LOCALE) {


### PR DESCRIPTION
## Summary

- Hide the two requested posts by switching their Markdown status to draft.
- Remove the now-unneeded theme action wrapper and replace post-list text shift with a subtle left-to-right hover fill.
- Add blog-detail back navigation, route/body loading states, richer Open Graph/Twitter metadata, and lighter canonical-slug lookup for database-backed post pages.

## Validation

- pnpm validate:content
- pnpm build

Note: content validation still reports the existing missing image in 2021-05-27-LifecycleFunc.md.