### PR TITLE
Redirect GitHub Pages to Vercel

### DIFF
--- a/.github/workflows/deploy-pages-redirect.yml
+++ b/.github/workflows/deploy-pages-redirect.yml
@@ -1,0 +1,41 @@
+name: Redirect GitHub Pages to Vercel
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - ".github/workflows/deploy-pages-redirect.yml"
+      - "github-pages-redirect/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload redirect site
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: github-pages-redirect
+
+      - name: Deploy redirect site
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ One-time setup:
 
    - `DATABASE_URL`
 
-5. **Disable GitHub Pages** for this repo (Settings → Pages → Source: *None*). This repo previously served a static site from `master`; after the Next.js refactor lands, Pages can no longer build it, so production should come from Vercel only.
+5. **Keep GitHub Pages as a redirect only.** The `deploy-pages-redirect.yml` workflow publishes the static files under `github-pages-redirect/`, so `https://hanqizheng.github.io/` and historical paths forward readers to the Vercel deployment. The Next.js application itself still runs only on Vercel because it depends on server rendering and Supabase.
 
 After the first production deploy, the publishing loop is fully automatic: commit a bilingual Markdown pair under `content/posts`, open a PR (Vercel builds a preview), and merge to `master` — the merge triggers the Vercel production deploy, and the `sync-posts` workflow loads the new Markdown into Supabase.
 

--- a/github-pages-redirect/404.html
+++ b/github-pages-redirect/404.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <title>Handler 已迁移</title>
+    <script>
+      (() => {
+        const destination = new URL("https://hanqizheng.vercel.app");
+        const currentPath = window.location.pathname;
+        destination.pathname =
+          currentPath === "/" || currentPath === "/index.html" ? "/zh" : currentPath;
+        destination.search = window.location.search;
+        destination.hash = window.location.hash;
+        window.location.replace(destination.toString());
+      })();
+    </script>
+    <noscript>
+      <meta http-equiv="refresh" content="0; url=https://hanqizheng.vercel.app/zh" />
+    </noscript>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+          sans-serif;
+      }
+
+      body {
+        display: grid;
+        min-height: 100vh;
+        place-items: center;
+        margin: 0;
+        color: CanvasText;
+        background: Canvas;
+      }
+
+      main {
+        padding: 24px;
+        text-align: center;
+      }
+
+      a {
+        color: inherit;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <p>博客已迁移，正在前往新地址。</p>
+      <a href="https://hanqizheng.vercel.app/zh">继续访问 Handler</a>
+    </main>
+  </body>
+</html>

--- a/github-pages-redirect/index.html
+++ b/github-pages-redirect/index.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <title>Handler 已迁移</title>
+    <script>
+      (() => {
+        const destination = new URL("https://hanqizheng.vercel.app");
+        const currentPath = window.location.pathname;
+        destination.pathname =
+          currentPath === "/" || currentPath === "/index.html" ? "/zh" : currentPath;
+        destination.search = window.location.search;
+        destination.hash = window.location.hash;
+        window.location.replace(destination.toString());
+      })();
+    </script>
+    <noscript>
+      <meta http-equiv="refresh" content="0; url=https://hanqizheng.vercel.app/zh" />
+    </noscript>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+          sans-serif;
+      }
+
+      body {
+        display: grid;
+        min-height: 100vh;
+        place-items: center;
+        margin: 0;
+        color: CanvasText;
+        background: Canvas;
+      }
+
+      main {
+        padding: 24px;
+        text-align: center;
+      }
+
+      a {
+        color: inherit;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <p>博客已迁移，正在前往新地址。</p>
+      <a href="https://hanqizheng.vercel.app/zh">继续访问 Handler</a>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## What changed

- Add a dedicated GitHub Pages workflow that deploys a static redirect artifact.
- Redirect `hanqizheng.github.io` root traffic to the Vercel Chinese homepage.
- Preserve historical paths, query strings, and hash fragments when forwarding old URLs.
- Document that GitHub Pages is a compatibility redirect while the SSR application remains hosted on Vercel.

## Why

The main redesign deployment correctly updated Vercel, but GitHub Pages retained a stale artifact last modified in 2023. Vercel cannot directly control the `hanqizheng.github.io` subdomain, so GitHub Pages needs its own deployment that forwards readers to the live Vercel application.

## Validation

- Workflow YAML parsed successfully
- `pnpm lint` passed with zero warnings
- `git diff --check` passed
- Official GitHub Pages workflow actions and permissions match the current GitHub documentation